### PR TITLE
Better publish.sh text and always copy package.json

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,18 +1,26 @@
 #!/bin/bash
 
+# clean all built assets.
 rm -rvf ./www/
 rm -rvf ./dist/
 npm run prod-electron
-cp ./package.json ./www/
 
+# generate package.json without dependencies.
+cp ./package.json ./www/
 if [[ "$OSTYPE" == "darwin"* ]]
 then
     sed -i '' '6,$d' ./www/package.json
 else
     sed -i '6,$d' ./www/package.json
 fi
-
 echo '  "main": "index.js"' >> ./www/package.json
 echo '}' >> ./www/package.json
+
+# call electron builder without publishing anything.
 ./node_modules/.bin/electron-builder -p never
+
+# cp package.json so that release server could read version number.
+cp ./package.json ./dist/
+
+# rename built files to avoid space in file names.
 for f in dist/*\ *; do mv "$f" "${f// /.}"; done


### PR DESCRIPTION
* clean all built assets.
* generate package.json without dependencies.
* call electron builder without publishing anything.
* rename built files to avoid space in file names.