### PR TITLE
fix #315

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "font-awesome": "^4.7.0",
     "he": "^1.2.0",
     "ngx-electron": "^2.1.1",
+    "opn": "^5.4.0",
     "rxjs": "^6.4.0",
     "sweetalert2": "^8.0.7",
     "zone.js": "^0.8.29"

--- a/src/app/Services/MessageService.ts
+++ b/src/app/Services/MessageService.ts
@@ -111,7 +111,15 @@ export class MessageService {
                         t.content = he.encode(t.content);
                         t.content = Autolinker.link(t.content, {
                             stripPrefix: false,
-                            className : 'chat-inline-link'
+                            className : 'chat-inline-link',
+                            replaceFn : (match) => {
+                                const tag = match.buildTag();
+                                if (this._electronService.isElectronApp) {
+                                    // add electron broswer flag
+                                    tag.setAttr('href', `electron-bs:${tag.getAttr('href')}`);
+                                }
+                                return tag;
+                            }
                         });
                     }
                 });

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const BrowserWindow = electron.BrowserWindow
 const path = require('path')
 const url = require('url')
 const platform = require('os').platform()
+const opn = require('opn');
 
 let mainWindow
 app.showExitNotif = true
@@ -57,6 +58,15 @@ function createWindow() {
         if (!app.isQuiting) {
             event.preventDefault()
             mainWindow.hide()
+        }
+    });
+
+    mainWindow.webContents.on("new-window",(event,url) => {
+        if(url.startsWith("unsafe:electron-bs:")) {
+            // should open in broswer
+            event.preventDefault();
+            let absUrl = url.substring(19);
+            opn(absUrl);
         }
     });
 }


### PR DESCRIPTION
fix #315
known issue:
when user drag the link to a text editor (such as notepad), the link will have a `unsafe:electron-bs:` prefix