### PR TITLE
Fix compatibility for Edge and Firefox

### DIFF
--- a/src/app/Styles/talking.css
+++ b/src/app/Styles/talking.css
@@ -232,10 +232,10 @@
 }
 
 .chat-part textarea {
-    width: 75%;
+    width: 100%;
     float: left;
     border: none;
-    border-radius: 6px 0 0 6px;
+    border-radius: 6px;
     transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s,width ease-in-out 0.15s;
     box-shadow: none;
     min-height: 34px;
@@ -246,9 +246,9 @@
     resize: none;
 }
 
-.chat-part .chatinput-extented {
-    width: 100%;
-    border-radius: 6px;
+.chat-part .chatinput-shorten {
+    width: 75%;
+    border-radius: 6px 0 0 6px;
 }
 
 :host-context(.theme-light) .chat-part textarea {
@@ -262,18 +262,21 @@
 }
 
 .chat-part button {
-    width: 25%;
+    visibility: hidden;
+    padding: 0px;
+    width: 0%;
+    opacity: 0;
     float: left;
     border-radius: 0 6px 6px 0;
     height: 34px;
     transition: all 0.15s ease-in-out;
 }
 
-.chat-part .sendbtn-hidden {
-    visibility: hidden;
-    padding: 0px;
-    width: 0%;
-    opacity: 0;
+.chat-part .sendbtn-shown {
+    visibility: visible;
+    padding: 0 16px;
+    width: 25%;
+    opacity: 1;
 }
 
 .button-part {

--- a/src/app/Styles/talking.css
+++ b/src/app/Styles/talking.css
@@ -244,6 +244,7 @@
     box-sizing: border-box;
     outline: none;
     resize: none;
+    overflow-x: hidden;
 }
 
 .chat-part .chatinput-shorten {

--- a/src/app/Views/talking.html
+++ b/src/app/Views/talking.html
@@ -82,8 +82,8 @@
 
 <div class="chat-action">
     <div class="chat-part" [ngClass]="{'chat-part-extented': !(content==undefined || content.trim().length === 0)}">
-        <textarea id="chatInput" [ngClass]="{'chatinput-extented': content==undefined || content.trim().length === 0}" [(ngModel)]="content" type="text" (click)="startInput()" rows="1" maxlength="500" (paste)="paste($event)" (drop)="drop($event)" (dragover)="preventDefault($event)"></textarea>
-        <button class="button success" [ngClass]="{'sendbtn-hidden': content==undefined || content.trim().length === 0}" (click)="send()" i18n="@@Send">Send</button>
+        <textarea id="chatInput" [ngClass]="{'chatinput-shorten': !(content==undefined || content.trim().length === 0)}" [(ngModel)]="content" type="text" (click)="startInput()" rows="1" maxlength="500" (paste)="paste($event)" (drop)="drop($event)" (dragover)="preventDefault($event)"></textarea>
+        <button class="button success" [ngClass]="{'sendbtn-shown':!(content==undefined || content.trim().length === 0)}" (click)="send()" i18n="@@Send">Send</button>
     </div>
     <div class="button-part" [ngClass]="{'button-part-invisible': !(content==undefined || content.trim().length === 0)}">
         <i class="fa fa-microphone" aria-hidden="true" (click)="record()" [ngClass]="{'red': recording}"></i>


### PR DESCRIPTION
Edge: the `send` button will flash in a very short time when loading talking.
Firefox: the `chat input` is too high