### PR TITLE
Fix an issue that the user may accidentally stop uploading.

### DIFF
--- a/src/app/Services/UploadService.ts
+++ b/src/app/Services/UploadService.ts
@@ -98,6 +98,7 @@ export class UploadService {
             html: '<div id="progressText">0%</div><progress id="uploadProgress" max="100"></progress>',
             showCancelButton: true,
             showConfirmButton: false,
+            allowOutsideClick: false
         });
         Swal.showLoading();
         Swal.enableButtons();


### PR DESCRIPTION
Fix an issue that the user may accidentally stop uploading.

When the file is uploaded about 99%, and the user clicked somewhere outside, all progress will lose. Very very SB.

This PR will prevent the user from touching outside.