### PR TITLE
Prevent the app to rotate.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,7 @@
     "background_color": "#fff",
     "theme_color": "#fff",
     "display": "standalone",
-    "orientation": "any",
+    "orientation": "portrait",
     "related_applications": [{
         "platform": "play",
         "url": "https://play.google.com/store/apps/details?id=com.aiursoft.kahla"


### PR DESCRIPTION
Prevent the app to rotate even when the user locks the screen.

In this mode, if the user locks the screen, the PWA app will not rotate.

But if the user did not lock it, it will rotate correctly. And this is expected.