### PR TITLE
Remove standard sign in method.

### DIFF
--- a/src/app/Controllers/signin.component.ts
+++ b/src/app/Controllers/signin.component.ts
@@ -1,14 +1,6 @@
 import { Component } from '@angular/core';
-import { AuthApiService } from '../Services/AuthApiService';
-import { Router } from '@angular/router';
-import Swal from 'sweetalert2';
-import { AiurCollection } from '../Models/AiurCollection';
-import { AiurProtocal } from '../Models/AiurProtocal';
-import { catchError } from 'rxjs/operators';
-import { InitService } from '../Services/InitService';
 import { ApiService } from '../Services/ApiService';
 import { ElectronService } from 'ngx-electron';
-import { HomeService } from '../Services/HomeService';
 
 @Component({
     templateUrl: '../Views/signin.html',
@@ -22,37 +14,8 @@ export class SignInComponent {
     public OAuthURL: string;
 
     constructor(
-        private authApiService: AuthApiService,
-        private router: Router,
-        private initService: InitService,
         public _electronService: ElectronService,
-        private homeService: HomeService,
         ) {
         this.OAuthURL = ApiService.serverAddress;
         }
-
-    public signin(): void {
-        if (this.connecting) {
-            return;
-        }
-        this.connecting = true;
-        this.authApiService.AuthByPassword(this.email, this.password)
-            .pipe(catchError(error => {
-                this.connecting = false;
-                Swal.fire('Network issue', 'Could not connect to Kahla server.', 'error');
-                return Promise.reject(error.message || error);
-            }))
-            .subscribe(t => {
-                if (t.code === 0) {
-                    this.router.navigate(['/home'], {replaceUrl: true});
-                    this.homeService.currentPage = 0;
-                    this.initService.init();
-                } else if (t.code === -10) {
-                    Swal.fire('Sign in failed', (t as AiurProtocal as AiurCollection<string>).items[0], 'error');
-                } else {
-                    Swal.fire('Sign in failed', t.message, 'error');
-                }
-                this.connecting = false;
-            });
-    }
 }

--- a/src/app/Services/AuthApiService.ts
+++ b/src/app/Services/AuthApiService.ts
@@ -19,13 +19,6 @@ export class AuthApiService {
         return this.apiService.Get(AuthApiService.serverPath + '/Version');
     }
 
-    public AuthByPassword(email: string, password: string): Observable<AiurProtocal> {
-        return this.apiService.Post(AuthApiService.serverPath + '/AuthByPassword', {
-            email: email,
-            password: password
-        });
-    }
-
     public SignInStatus(): Observable<AiurValue<boolean>> {
         return this.apiService.Get(AuthApiService.serverPath + '/SignInStatus');
     }

--- a/src/app/Styles/signin.scss
+++ b/src/app/Styles/signin.scss
@@ -46,7 +46,7 @@
 .auth-content {
   width: 290px;
   max-width: 80%;
-  margin: 30% auto 5% auto;
+  margin: 50% auto 5% auto;
 }
 
 input {

--- a/src/app/Views/signin.html
+++ b/src/app/Views/signin.html
@@ -3,23 +3,12 @@
         <div class="auth-header">
             <img src="assets/144x144.png">
             <h1 i18n="@@Kahla">Kahla</h1>
-            <h3 i18n="@@SignIn">Sign In</h3>
         </div>
         <div class="auth-content">
-            <form (ngSubmit)="signin()" #loginForm="ngForm">
-                <input [(ngModel)]="email" name="email" type="email" i18n-placeholder="@@Email" placeholder="Email" autocomplete="email" required #emailInput="ngModel" email>
-                <div class="alert" [hidden]="emailInput.valid || emailInput.pristine">Invalid email!</div>
-                <input [(ngModel)]="password" name="password" type="password" minlength="6" maxlength="100" i18n-placeholder="@@Password" placeholder="Password" autocomplete="current-password" (keyup.enter)="signin()" required #passwordInput="ngModel">
-                <div class="alert" [hidden]="passwordInput.valid || passwordInput.pristine">Password length should between 6 and 100.</div>
-                <button *ngIf="!connecting" [disabled]="!loginForm.form.valid" class="button white" i18n="@@LogIn" type="submit">
-                    Sign in
-                </button>
-                <button *ngIf="connecting" disabled="disabled" class="button white" i18n="@@Connecting" type="button">
-                    Connecting...
-                </button>
+            <form>
                 <a class="button white login" href="{{ OAuthURL }}/Auth/Oauth"
                    [target]="_electronService.isElectronApp ? '_blank' : ''">
-                    Sign in with browser(OAuth)
+                    Sign in
                 </a>
                 <a class="button white login" href="{{ OAuthURL }}/Auth/GoRegister"
                    [target]="_electronService.isElectronApp ? '_blank' : ''">


### PR DESCRIPTION
Standard sign-in API is dangerous. And hard to maintain. Sign in method shall be single.

In the future, we may add some 2fa sign method. Changing this will prevent changing Kahla.App code more.